### PR TITLE
Fix gesture preview crash on macOS 12

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -15,13 +15,12 @@ License: GPL-3.0-or-later
 
 
 ### Third-party
-# Files that originate from elsewhere, but are not availabe e.g. via CocoaPods
+# Files that originate from elsewhere, but are not available e.g. via CocoaPods
 
 # MAAttachedWindow
 # Matt Gemmell kindly re-licensed MAAttachedWindow for inclusion in Jitouch, to
 # avoid uncertain compatibility between his custom BSD-like license and GPL-3.0
 Files: PreferencePane/MAAttachedWindow.h
-       PreferencePane/MAAttachedWindow.m
 Copyright: 2007 Magic Aubergine
 License: GPL-3.0-or-later
 

--- a/PreferencePane/MAAttachedWindow.m
+++ b/PreferencePane/MAAttachedWindow.m
@@ -1,9 +1,23 @@
-//
-//  MAAttachedWindow.m
-//
-//  Created by Matt Gemmell on 27/09/2007.
-//  Copyright 2007 Magic Aubergine.
-//
+/*
+ * This file is part of Jitouch.
+ *
+ * Copyright 2007 Magic Aubergine
+ * Copyright 2021 Aaron Kollasch
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Jitouch is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Jitouch is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Jitouch. If not, see <https://www.gnu.org/licenses/>.
+ */
 
 #import "MAAttachedWindow.h"
 
@@ -320,24 +334,14 @@
 
 - (NSColor *)_backgroundColorPatternImage
 {
-    NSImage *bg = [[NSImage alloc] initWithSize:[self frame].size];
-    NSRect bgRect = NSZeroRect;
-    bgRect.size = [bg size];
-
-    [bg lockFocus];
-    NSBezierPath *bgPath = [self _backgroundPath];
-    [NSGraphicsContext saveGraphicsState];
-    [bgPath addClip];
-
-    // Draw background.
-    [_MABackgroundColor set];
-    [bgPath fill];
-    //[bgPath stroke];
-
-    [NSGraphicsContext restoreGraphicsState];
-    [bg unlockFocus];
-
-    return [NSColor colorWithPatternImage:bg];
+    // TODO: Consider restoring old visual style
+    // using imageWithSize:flipped:drawingHandler e.g.:
+    /*
+    NSImage *bg = [NSImage imageWithSize:[self frame].size
+                                 flipped:NO
+                          drawingHandler:???];
+    */
+    return [NSColor lightGrayColor];  // Return static color for now.
 }
 
 


### PR DESCRIPTION
`[NSView lockFocus]` was [deprecated](http://codeworkshop.net/objc-diff/sdkdiffs/macos/10.14/AppKit.html) in macOS 10.14 and seems to be removed on 12.0.
This PR prevents the prefpane from crashing while trying to show the gesture preview window. It uses a single background color as a substitute for a drawn background, though it is not as pretty.
`imageWithSize:flipped:drawingHandler` is a potential replacement for `lockFocus`, e.g.
```
NSImage *bg = [NSImage imageWithSize:[self frame].size
                                 flipped:NO
                          drawingHandler:???];
```