### PR TITLE
Switch to using a LaunchAgent

### DIFF
--- a/PreferencePane/io.github.jitouchproject.Jitouch.plist
+++ b/PreferencePane/io.github.jitouchproject.Jitouch.plist
@@ -22,5 +22,11 @@
 		<key>SuccessfulExit</key>
 		<false/>
 	</dict>
+	<key>ProcessType</key>
+	<string>Interactive</string>
+	<key>StandardErrorPath</key>
+	<string>/dev/null</string>
+	<key>StandardOutPath</key>
+	<string>/dev/null</string>
 </dict>
 </plist>


### PR DESCRIPTION
This PR removes Jitouch from the login items, adds a LaunchAgent plist file to `~/Library/LaunchAgents/`, and loads it with `launchctl load`. Unlike the login item, the LaunchAgent will ensure that Jitouch is always running.

To unload the LaunchAgent, use "Quit Jitouch" in the menu bar item. To load, switch Jitouch to "On" in the Preferences Pane (click "On" even if it is already selected).